### PR TITLE
Raise error if input is invalid

### DIFF
--- a/lib/munkres_ru.rb
+++ b/lib/munkres_ru.rb
@@ -29,7 +29,7 @@ module MunkresRu
     pointer.autorelease = false # Rust will take ownership of that memory
     pointer.put_array_of_double 0, flattened
     solved = MunkresRu.solve_munkres(array.size, pointer).to_a
-    if solved.include?(-1)
+    if solved == [-1]
       raise 'Solving Munkres problem failed, check if input is valid'
     end
     solved.each_slice(2).to_a

--- a/lib/munkres_ru.rb
+++ b/lib/munkres_ru.rb
@@ -30,7 +30,7 @@ module MunkresRu
     pointer.put_array_of_double 0, flattened
     solved = MunkresRu.solve_munkres(array.size, pointer).to_a
     if solved.include?(-1)
-      raise 'Solving Munkres problem failed, check input is valid'
+      raise 'Solving Munkres problem failed, check if input is valid'
     end
     solved.each_slice(2).to_a
   end

--- a/lib/munkres_ru.rb
+++ b/lib/munkres_ru.rb
@@ -28,6 +28,10 @@ module MunkresRu
     pointer = FFI::MemoryPointer.new :double, flattened.size
     pointer.autorelease = false # Rust will take ownership of that memory
     pointer.put_array_of_double 0, flattened
-    MunkresRu.solve_munkres(array.size, pointer).to_a.each_slice(2).to_a
+    solved = MunkresRu.solve_munkres(array.size, pointer).to_a
+    if solved.include?(-1)
+      raise 'Solving Munkres problem failed, check input is valid'
+    end
+    solved.each_slice(2).to_a
   end
 end

--- a/lib/munkres_ru/version.rb
+++ b/lib/munkres_ru/version.rb
@@ -1,3 +1,3 @@
 module MunkresRu
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,12 +40,6 @@ pub extern fn solve_munkres(n: libc::size_t, array: *mut libc::c_double) -> Arra
     });
     match res {
         Ok(array) => array,
-        Err(_) => {
-            let mut err_res = Vec::new();
-            for _ in 0..n {
-                err_res.push(-1 as libc::c_int);
-            }
-            Array::from_vec(err_res)
-        }
+        Err(_) => Array::from_vec(vec![-1]),
     }
 }

--- a/spec/munkres_ru_spec.rb
+++ b/spec/munkres_ru_spec.rb
@@ -55,4 +55,17 @@ describe MunkresRu do
     solution = MunkresRu.solve(problem)
     expect(compute_cost(problem, solution)).to eq(3.0)
   end
+
+  it 'raises exception on NaN' do
+    problem = [
+      [Float::NAN, 1.0, 1.0, 1.0, 1.0],
+      [1.0, Float::NAN, 1.0, 1.0, 1.0],
+      [1.0, 1.0, Float::NAN, 1.0, 1.0],
+      [0.0, 0.0, 0.0, Float::INFINITY, 0.0],
+      [0.0, 0.0, 0.0, 0.0, Float::INFINITY]
+    ]
+    expect {
+      MunkresRu.solve(problem)
+    }.to raise_error('Solving Munkres problem failed, check input is valid')
+  end
 end

--- a/spec/munkres_ru_spec.rb
+++ b/spec/munkres_ru_spec.rb
@@ -66,6 +66,6 @@ describe MunkresRu do
     ]
     expect {
       MunkresRu.solve(problem)
-    }.to raise_error('Solving Munkres problem failed, check input is valid')
+    }.to raise_error('Solving Munkres problem failed, check if input is valid')
   end
 end


### PR DESCRIPTION
The solver hangs if the input contains NaN. This asserts that the input is valid, and raises an error if Rust execution fails.