### PR TITLE
Fix memory leak

### DIFF
--- a/lib/munkres_ru.rb
+++ b/lib/munkres_ru.rb
@@ -21,17 +21,20 @@ module MunkresRu
     end
   end
 
-  attach_function :solve_munkres, [:size_t, :pointer], ResultArray.by_value
+  attach_function :solve_munkres, [:size_t, :pointer], ResultArray
+  attach_function :free_munkres, [ :pointer ], :void
 
   def self.solve(array)
     flattened = array.flatten
     pointer = FFI::MemoryPointer.new :double, flattened.size
     pointer.autorelease = false # Rust will take ownership of that memory
     pointer.put_array_of_double 0, flattened
-    solved = MunkresRu.solve_munkres(array.size, pointer).to_a
-    if solved == [-1]
+    result_pointer = MunkresRu.solve_munkres(array.size, pointer)
+    if result_pointer.null?
       raise 'Solving Munkres problem failed, check if input is valid'
     end
-    solved.each_slice(2).to_a
+    result = ResultArray.new(result_pointer).to_a.each_slice(2).to_a
+    self.free_munkres(result_pointer)
+    result
   end
 end

--- a/lib/munkres_ru.rb
+++ b/lib/munkres_ru.rb
@@ -26,10 +26,11 @@ module MunkresRu
 
   def self.solve(array)
     flattened = array.flatten
-    pointer = FFI::MemoryPointer.new :double, flattened.size
-    pointer.autorelease = false # Rust will take ownership of that memory
-    pointer.put_array_of_double 0, flattened
-    result_pointer = MunkresRu.solve_munkres(array.size, pointer)
+    result_pointer = nil
+    FFI::MemoryPointer.new(:double, flattened.size) do |pointer|
+      pointer.put_array_of_double 0, flattened
+      result_pointer = MunkresRu.solve_munkres(array.size, pointer)
+    end
     if result_pointer.null?
       raise 'Solving Munkres problem failed, check if input is valid'
     end

--- a/lib/munkres_ru/version.rb
+++ b/lib/munkres_ru/version.rb
@@ -1,3 +1,3 @@
 module MunkresRu
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/munkres_ru.gemspec
+++ b/munkres_ru.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.extensions = Dir['rust/extconf.rb']
+  spec.add_runtime_dependency 'ffi', '~> 1.9'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,18 +2,18 @@
 name = "munkres_ru"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "munkres 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.23"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -21,10 +21,10 @@ name = "munkres"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fixedbitset 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum fixedbitset 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fcf4412e2d11115c5ed81c2fbdaba8028de0c92553497aa771fc5f4e0c5c8793"
-"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum fixedbitset 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b0cb3d75726fa0c5ed3dce5dfcf0796affa2a60b33967f45012d86fb95a886f2"
+"checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
 "checksum munkres 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84ca023813adf830e2537250f471f9928ff581527fe87d08a641f68b1b46c3e7"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,16 +4,21 @@ extern crate libc;
 use munkres::WeightMatrix;
 use munkres::solve_assignment;
 
+use libc::{c_int, size_t};
+
 #[repr(C)]
 pub struct Array {
     len: libc::size_t,
-    data: *const libc::c_int,
+    data: *const c_int,
 }
 
 impl Array {
-    fn from_vec(mut vec: Vec<i32>) -> Array {
+    fn from_vec(mut vec: Vec<c_int>) -> Array {
         vec.shrink_to_fit();
-        let array = Array { data: vec.as_ptr() as *const libc::c_int, len: vec.len() as libc::size_t };
+        let array = Array {
+            data: vec.as_ptr() as *const c_int,
+            len: vec.len() as size_t,
+        };
         std::mem::forget(vec);
         array
     }
@@ -21,40 +26,36 @@ impl Array {
 
 impl Drop for Array {
     fn drop(&mut self) {
-        unsafe { Vec::from_raw_parts(self.data as *mut i32, self.len, self.len) as Vec<i32> };
+        unsafe { Vec::from_raw_parts(self.data as *mut c_int, self.len, self.len) as Vec<c_int> };
     }
 }
 
 
 #[no_mangle]
-pub extern fn solve_munkres(n: libc::size_t, array: *mut libc::c_double) -> *mut Array {
+pub extern "C" fn solve_munkres(n: libc::size_t, array: *mut libc::c_double) -> *mut Array {
     let res = ::std::panic::catch_unwind(|| {
         let size = n as usize;
-        let len = size*size;
+        let len = size * size;
         let vec = unsafe { Vec::from_raw_parts(array, len, len) };
-        for &v in &vec {
+        for v in &vec {
             assert!(!v.is_nan());
         }
         let mut weights: WeightMatrix<libc::c_double> = WeightMatrix::from_row_vec(size, vec);
         let matching = solve_assignment(&mut weights);
         let mut res = Vec::new();
-        for &(row, col) in &matching[..] {
+        for (row, col) in matching {
             res.push(row as libc::c_int);
             res.push(col as libc::c_int);
         }
         Box::new(Array::from_vec(res))
     });
     match res {
-        Ok(array) => {
-            Box::into_raw(array)
-        },
+        Ok(array) => Box::into_raw(array),
         Err(_) => std::ptr::null_mut(),
     }
 }
 
 #[no_mangle]
-pub extern fn free_munkres(array: *mut Array) {
-    let _res = ::std::panic::catch_unwind(|| {
-        unsafe { Box::from_raw(array) };
-    });
+pub extern "C" fn free_munkres(array: *mut Array) {
+    let _res = ::std::panic::catch_unwind(|| { unsafe { Box::from_raw(array) }; });
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -48,7 +48,7 @@ pub extern fn solve_munkres(n: libc::size_t, array: *mut libc::c_double) -> *mut
         Ok(array) => {
             Box::into_raw(array)
         },
-        Err(_) => 0 as *mut Array,
+        Err(_) => std::ptr::null_mut(),
     }
 }
 


### PR DESCRIPTION
Pass structs by reference.
Also add a separate function to free the memory allocated by rust.
It casts a pointer back to a rust struct, which will be dropped properly by rust,
more over we define a custom destructor for the struct, so that we free the hidden behind the pointers `Vec`.

Current code is leaking memory because the underlying `Vector` (which we `mem::forget` here:  (https://github.com/deliveroo/munkres_ru/blob/89bfea21f96ad994fef0f766b9f5ff66d6143d98/rust/src/lib.rs#L17) is never dropped.
Ruby only drops the `Array` struct, but doesn't do this recursively for the references inside it.